### PR TITLE
Introduce web frontend and update server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Cross-Platform AR Object Spotter
+# YOLOv8 Detection Web Service
 
-This project is a starting point for an Unreal Engine application that streams camera frames to a YOLOv8 server. The Python service runs on an Ubuntu machine with ROCm GPU acceleration and returns bounding boxes that the client overlays in real time.
+This project provides a simple FastAPI backend that performs object detection with YOLOv8 on an Ubuntu machine with ROCm GPU acceleration. A lightweight website served from the `web/` directory allows you to upload images and view detection results.
 
 ## Components
 
-* `server/` – FastAPI WebSocket service running YOLOv8 inference.
-* `unreal/` – Example files for integrating detection results inside Unreal Engine.
+* `server/` – FastAPI service performing YOLOv8 inference via HTTP or WebSocket.
+* `web/` – Placeholder directory for your website files. `index.html` demonstrates uploading an image.
 * `requirements.txt` – Python package list for the server environment.
 
 ## Quick start
@@ -14,10 +14,10 @@ This project is a starting point for an Unreal Engine application that streams c
    ```bash
    pip install -r requirements.txt
    ```
-2. Run the detection server:
+2. Start the server:
    ```bash
    uvicorn server.fastapi_server:app --host 0.0.0.0 --port 8000
    ```
-3. Build the Unreal project for Android or Windows and send JPEG frames to `/detect`.
+3. Open `http://<server-ip>:8000` in your browser and upload an image to test detection.
 
-Place your training dataset under `server/data/` with a `data.yaml` file. The files `server/train.py` and `server/predict.py` are empty placeholders where you can add your own training and evaluation code.
+Place your training dataset under `server/data/` with a `data.yaml` file. The files `server/train.py` and `server/predict.py` contain example scripts you can adapt for training and evaluation on your ROCm GPU.

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ psutil==5.9.8
 # Async server utilities (for high performance)
 aiohttp==3.9.5
 aiofiles==23.2.1
+python-multipart==0.0.9

--- a/server/README.md
+++ b/server/README.md
@@ -1,19 +1,14 @@
 # YOLOv8 Detection Server
 
-This folder contains a FastAPI WebSocket server that runs YOLOv8 object detection. Clients send base64-encoded JPEG images and receive detection results as JSON.
+This directory contains the FastAPI backend that performs object detection. When started with `uvicorn`, the server also serves the website located in `../web`.
 
 ## Usage
 
-Install dependencies from the project root:
+Install dependencies from the project root and run the server:
 
 ```bash
 pip install -r requirements.txt
-```
-
-Run the server (downloads YOLOv8 weights on first launch):
-
-```bash
 uvicorn server.fastapi_server:app --host 0.0.0.0 --port 8000
 ```
 
-The server exposes a WebSocket endpoint at `/detect`. Send a base64 JPEG string and you will receive a JSON array of detections with class IDs and pixel coordinates.
+Open `http://<server-ip>:8000` in a browser. The `/api/detect` endpoint accepts image uploads via POST and `/ws` provides a WebSocket interface for real-time streaming.

--- a/server/fastapi_server.py
+++ b/server/fastapi_server.py
@@ -1,14 +1,45 @@
-from fastapi import FastAPI, WebSocket
+from pathlib import Path
+from fastapi import FastAPI, WebSocket, UploadFile, File
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
 from ultralytics import YOLO
 import cv2
 import numpy as np
 import base64
 
-app = FastAPI()
-model = YOLO("/home/agam/Downloads/codeclash/git/server/best.pt")  # your trained checkpoint
+# Paths
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WEB_DIR = REPO_ROOT / "web"
+MODEL_PATH = Path(__file__).with_name("best.pt")
 
-@app.websocket("/detect")
-async def detect(ws: WebSocket):
+app = FastAPI()
+app.mount("/static", StaticFiles(directory=WEB_DIR), name="static")
+
+@app.get("/")
+async def get_index():
+    return FileResponse(WEB_DIR / "index.html")
+
+model = YOLO(str(MODEL_PATH))
+
+@app.post("/api/detect")
+async def api_detect(file: UploadFile = File(...)):
+    data = await file.read()
+    img = cv2.imdecode(np.frombuffer(data, np.uint8), cv2.IMREAD_COLOR)
+    res = model.predict(img, conf=0.25, verbose=False)[0]
+    detections = [
+        {
+            "cls": int(b.cls),
+            "x1": float(b.xyxy[0][0]),
+            "y1": float(b.xyxy[0][1]),
+            "x2": float(b.xyxy[0][2]),
+            "y2": float(b.xyxy[0][3]),
+        }
+        for b in res.boxes
+    ]
+    return {"detections": detections}
+
+@app.websocket("/ws")
+async def ws_detect(ws: WebSocket):
     await ws.accept()
     while True:
         jpg_b64 = await ws.receive_text()

--- a/unreal/README.md
+++ b/unreal/README.md
@@ -1,5 +1,0 @@
-# Unreal Client
-
-This folder outlines how to connect an Unreal Engine project to the YOLOv8 server. Create a Blueprint Function Library (for example `BP_ImageStreamer`) that captures the camera texture each tick, encodes it as JPEG and sends it to `/detect` via WebSocket. The JSON reply contains bounding box coordinates which can be drawn using UMG widgets.
-
-See the repository root README for an overview of the entire system.

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,5 @@
+# Web Frontend
+
+Place your website files in this directory. The FastAPI server serves `index.html` from here so you can develop a simple frontend for object detection.
+
+The default `index.html` demonstrates how to upload an image to `/api/detect` and display the JSON response.

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>YOLOv8 Detector</title>
+</head>
+<body>
+    <h1>YOLOv8 Detector</h1>
+    <input type="file" id="imgInput" accept="image/*" />
+    <button id="sendBtn">Detect</button>
+    <pre id="output"></pre>
+
+    <script>
+    document.getElementById('sendBtn').onclick = async function() {
+        const input = document.getElementById('imgInput');
+        if (!input.files.length) return;
+        const data = new FormData();
+        data.append('file', input.files[0]);
+        const res = await fetch('/api/detect', {method: 'POST', body: data});
+        const json = await res.json();
+        document.getElementById('output').textContent = JSON.stringify(json, null, 2);
+    };
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- remove Unreal client
- add `web/` frontend with upload demo
- serve web files from FastAPI server
- document web setup in READMEs
- add `python-multipart` requirement

## Testing
- `python -m py_compile server/fastapi_server.py server/predict.py server/train.py`

------
https://chatgpt.com/codex/tasks/task_e_685cd618c5f483309e90d6362b99f50d