### PR TITLE
Add demo page and improve WebSocket server

### DIFF
--- a/web/frontend/src/App.css
+++ b/web/frontend/src/App.css
@@ -365,6 +365,7 @@ body::before {
   border-radius: 12px;
   border: 2px solid rgba(46, 255, 255, 0.3);
   box-shadow: 0 0 30px rgba(46, 255, 255, 0.2);
+  transform: scaleX(-1);
 }
 
 .detection-overlay {
@@ -373,6 +374,7 @@ body::before {
   left: 2rem;
   pointer-events: none;
   border-radius: 12px;
+  transform: scaleX(-1);
 }
 
 .controls {
@@ -919,6 +921,7 @@ body::before {
   .video-feed {
     width: 100%;
     height: auto;
+    transform: scaleX(-1);
   }
   
   .hero-content h1 {

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Live YOLOv8 on the Web</title>
+  <style>
+    video, canvas {
+      position: absolute; left: 0; top: 0;
+      transform: scaleX(-1); /* mirror */
+    }
+  </style>
+</head>
+<body>
+  <video id="video" width="640" height="480" autoplay muted></video>
+  <canvas id="canvas" width="640" height="480"></canvas>
+
+  <script>
+  const video = document.getElementById('video');
+  const canvas = document.getElementById('canvas');
+  const ctx = canvas.getContext('2d');
+
+  // 1. Get webcam
+  navigator.mediaDevices.getUserMedia({ video: true })
+    .then(stream => { video.srcObject = stream; })
+    .catch(console.error);
+
+  // 2. Open WebSocket
+  const ws = new WebSocket(`ws://${location.host}/ws`);
+  ws.onopen = () => {
+    console.log('WebSocket connected');
+    sendFrameLoop();
+  };
+  ws.onmessage = msg => {
+    // draw the boxes
+    const dets = JSON.parse(msg.data);
+    ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+    ctx.lineWidth = 2; ctx.strokeStyle = 'lime';
+    dets.forEach(d => {
+      ctx.strokeRect(d.x1, d.y1, d.x2 - d.x1, d.y2 - d.y1);
+      ctx.fillText(d.conf.toFixed(2), d.x1, d.y1 - 5);
+    });
+  };
+
+  // 3. Capture & send frames
+  function sendFrameLoop() {
+    const off = document.createElement('canvas');
+    off.width = video.videoWidth;
+    off.height = video.videoHeight;
+    const offCtx = off.getContext('2d');
+    offCtx.drawImage(video, 0, 0);
+    off.toBlob(blob => {
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        ws.send(reader.result); // sends "data:image/png;base64,...."
+      };
+      reader.readAsDataURL(blob);
+    }, 'image/jpeg', 0.6);
+    setTimeout(sendFrameLoop, 66); // ~15 fps
+  }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `web/index.html` to demonstrate live webcam detection
- handle data URLs and add throttling in `server/fastapi_server.py`
- adjust backend server to return bbox coordinates and throttle
- mirror webcam feed in React styles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dee720c9c8330852d48ab4bfff43b